### PR TITLE
Adversary list aliases

### DIFF
--- a/commands/AdversaryNames.js
+++ b/commands/AdversaryNames.js
@@ -35,7 +35,7 @@ var england ={
     emote: '<:FlagEngland:742199440126771250>', 
     difficulty: [ 1, 3, 4, 6, 7, 9, 10],
     panel: "https://imgur.com/c5KzcIq",
-    alias: ["<:FlagEngland:742199440126771250>'"]   
+    alias: ["<:FlagEngland:742199440126771250>"]   
 }
 
 var france ={

--- a/commands/adversary.js
+++ b/commands/adversary.js
@@ -4,29 +4,40 @@ const getcardname = require('./sendCardLink.js').getCardName;
 
 module.exports = {
 	name: 'adversary',
-	description: 'Get an adversary',
+	description: 'Get a single adversary panel',
 	public: true,
 	async execute(msg, args) {          
-        var panel =  "Adversaries are \nPrussia, England, France, Habsburg (Livestock-Colony, HLC, Cowburg), Habsburg (Mining-Expedition, HME, Saltburg), Russia, Scotland, Sweden";
+        var panel =  "";
         var found = false;
         var list = [];
         
+        // if an adversary parameter is provided
         if (args.length != 0){
            const searchString = args[0].toLowerCase();
            for(const adversary of ad.adversaries){
-                console.log(adversary);
                 // direct match
                 if(adversary.name.toLowerCase().indexOf(searchString) >= 0) {
                     panel = adversary.panel;
+                    found = true;
+                    break;
                 }
                 // alias
                 else{
                     for (const alias of adversary.alias){
                         if (alias.toLowerCase().indexOf(searchString) >= 0){
                             panel = adversary.panel;
+                            found = true;
+                            break;
                         }
                     }
                 }
+            }
+        }
+        // if no match found or no argument provided, assume they want a list of adversaries
+        if (args.length == 0 | !found){
+            panel = "Choose an adversary: (aliases) \n";
+            for (const adversary of ad.adversaries){
+                panel += "* " + adversary.name + " (" + adversary.alias.join(" , ") + ")\n";
             }
         }
 

--- a/commands/adversary.js
+++ b/commands/adversary.js
@@ -15,8 +15,9 @@ module.exports = {
         if (args.length != 0){
            const searchString = args[0].toLowerCase();
            for(const adversary of ad.adversaries){
-                // direct match
-                if(adversary.name.toLowerCase().indexOf(searchString) >= 0) {
+                // if there is a panel with that string in the title, return it
+                // checks for exact title matches to avoid Prussia - Russia problem
+                if(adversary.title.toLowerCase() == searchString) {
                     panel = adversary.panel;
                     found = true;
                     break;
@@ -35,9 +36,9 @@ module.exports = {
         }
         // if no match found or no argument provided, assume they want a list of adversaries
         if (args.length == 0 | !found){
-            panel = "Choose an adversary: (aliases) \n";
+            panel = "Choose an adversary: \n";
             for (const adversary of ad.adversaries){
-                panel += "* " + adversary.name + " (" + adversary.alias.join(" , ") + ")\n";
+                panel += "* " + adversary.name + " (" + adversary.title + ", " + adversary.alias.join(" , ") + ")\n";
             }
         }
 


### PR DESCRIPTION
Added a list of valid aliases to search for an adversary by and fixed a potential issue where adversaries with similar names (i.e. Prussia/Russia, Habsburg) could overwrite if they were defined later in adversaries.js.